### PR TITLE
Add support for AWS profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Added support for AWS Profile
+
 ## [0.1.9][] - 2023-04-03
 [0.1.9]: https://github.com/awslabs/aws-az-failure-chaostoolkit/tree/v0.1.9
 

--- a/azchaosaws/__init__.py
+++ b/azchaosaws/__init__.py
@@ -37,6 +37,7 @@ def client(resource_name: str, configuration: Configuration = None):
     params = dict()
 
     region = configuration.get("aws_region")
+    aws_profile_name = configuration.get("aws_profile_name")
     if not region:
         region = os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION"))
         if not region:
@@ -46,9 +47,14 @@ def client(resource_name: str, configuration: Configuration = None):
         logger.debug("Using AWS region '{}'".format(region))
         params["region_name"] = region
 
-    session = boto3.Session(**params)
-
-    return session.client(resource_name, **params)
+    if boto3.DEFAULT_SESSION is None:
+        boto3.setup_default_session(profile_name=aws_profile_name, **params)
+    logger.debug(
+        "Client will be using profile '{}'".format(
+            aws_profile_name or "default"
+        )
+    )
+    return boto3.client(resource_name, **params)
 
 
 ###############################################################################


### PR DESCRIPTION
This PR adds support for using different AWS profile. Users may pass `aws_profile_name` value to the `configuration` object so that we load the appropriate profile to use with AWS services. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Fixes #7 